### PR TITLE
Add support to get FMBench Log file from remote machine

### DIFF
--- a/configs/config.yml
+++ b/configs/config.yml
@@ -90,17 +90,3 @@ instances:
   fmbench_complete_timeout: 2400
   fmbench_config: https://raw.githubusercontent.com/aws-samples/foundation-model-benchmarking-tool/refs/heads/main/src/fmbench/configs/llama3/8b/config-ec2-llama3-8b-g6e-2xlarge.yml
 
-- instance_type: g6e.4xlarge
-  region: us-east-1
-  ami_id: ami-067bd563cecc90173
-  device_name: /dev/sda1
-  ebs_del_on_termination: True
-  ebs_Iops: 16000
-  ebs_VolumeSize: 250
-  ebs_VolumeType: gp3
-  startup_script: startup_scripts/gpu_ubuntu_startup.txt
-  post_startup_script: post_startup_scripts/fmbench.txt
-  # Timeout period in Seconds before a run is stopped
-  fmbench_complete_timeout: 2400
-  fmbench_config: https://raw.githubusercontent.com/aws-samples/foundation-model-benchmarking-tool/refs/heads/main/src/fmbench/configs/llama3/8b/config-llama3-8b-g6e.4xl-tp-1-mc-max-triton-ec2.yml
-  byo_dataset_fpath: byo_dataset/custom.jsonl

--- a/constants.py
+++ b/constants.py
@@ -31,7 +31,7 @@ MAX_WAIT_TIME_FOR_STARTUP_SCRIPT_IN_SECONDS: int = 1200
 SCRIPT_CHECK_INTERVAL_IN_SECONDS: int = 60
 FMBENCH_LOG_PATH: str = "~/fmbench.log"
 CLOUD_INITLOG_PATH: str = "/var/log/cloud-init-output.log"
-
+FMBENCH_LOG_REMOTE_PATH: str = "/home/{username}/fmbench.log"
 # misc directory paths
 RESULTS_DIR: str = "results"
 DOWNLOAD_DIR_FOR_CFG_FILES: str = "downloaded_configs"

--- a/main.py
+++ b/main.py
@@ -120,7 +120,7 @@ async def execute_fmbench(instance, formatted_script, remote_script_path):
             get_fmbench_log,
             instance,
             results_folder,
-            FMBENCH_LOG_PATH,
+            FMBENCH_LOG_REMOTE_PATH,
         )
 
         if fmbench_complete:

--- a/utils.py
+++ b/utils.py
@@ -569,7 +569,7 @@ def get_fmbench_log(instance: Dict, local_folder_base: str, log_file_path: str):
     username = instance["username"]
     key_file_path = instance["key_file_path"]
     instance_name = instance["instance_name"]
-
+    log_file_path = log_file_path.format(username=username)
     # Define local folder to store the log file
     local_folder = os.path.join(local_folder_base, instance_name)
     local_log_file = os.path.join(local_folder, 'fmbench.log')


### PR DESCRIPTION
This PR adds support to get FMBench log file from Remote Machine. This gets the log file even if a run fails which is helpful to know why a run might have failed.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
