### PR TITLE
Additional params addition + config files for Qwen

### DIFF
--- a/configs/qwen/fmbench_qwen.yml
+++ b/configs/qwen/fmbench_qwen.yml
@@ -1,0 +1,238 @@
+# config file for a rest endpoint supported on fmbench - 
+# this file uses a Qwen2.5-72b deployed on ec2
+general:
+  # if it is auto, then retrieve the model id and the instance type/container - 
+  # derive the name based on that (?)
+  # if name: name, then provide the name as -A <model-id-instance>
+  name: {results_dir}
+  model_name: {model_id}
+  
+# AWS and SageMaker settings
+aws:
+  # AWS region, this parameter is templatized, no need to change
+  region: {region}
+  # SageMaker execution role used to run FMBench, this parameter is templatized, no need to change
+  sagemaker_execution_role: {role_arn}
+  # S3 bucket to which metrics, plots and reports would be written to
+  bucket: {write_bucket} ## add the name of your desired bucket
+
+# directory paths in the write bucket, no need to change these
+dir_paths:
+  data_prefix: data
+  prompts_prefix: prompts
+  all_prompts_file: all_prompts.csv
+  metrics_dir: metrics
+  models_dir: models
+  metadata_dir: metadata
+
+# S3 information for reading datasets, scripts and tokenizer
+s3_read_data:
+  # read bucket name, templatized, if left unchanged will default to sagemaker-fmbench-read-region-account_id
+  read_bucket: {read_bucket}
+  scripts_prefix: scripts ## add your own scripts in case you are using anything that is not on jumpstart
+  
+  # S3 prefix in the read bucket where deployment and inference scripts should be placed
+  scripts_prefix: scripts
+    
+  # deployment and inference script files to be downloaded are placed in this list
+  # only needed if you are creating a new deployment script or inference script
+  # your HuggingFace token does need to be in this list and should be called "hf_token.txt"
+  script_files:
+  - hf_token.txt
+
+  # configuration files (like this one) are placed in this prefix
+  configs_prefix: configs
+
+  # list of configuration files to download, for now only pricing.yml needs to be downloaded
+  config_files:
+  - pricing.yml
+
+  # S3 prefix for the dataset files
+  source_data_prefix: source_data
+  # list of dataset files, the list below is from the LongBench dataset https://huggingface.co/datasets/THUDM/LongBench
+  source_data_files:
+  - 2wikimqa_e.jsonl
+  - 2wikimqa.jsonl
+  - hotpotqa_e.jsonl
+  - hotpotqa.jsonl
+  - narrativeqa.jsonl
+  - triviaqa_e.jsonl
+  - triviaqa.jsonl
+
+  # S3 prefix for the tokenizer to be used with the models
+  # NOTE 1: the same tokenizer is used with all the models being tested through a config file
+  # NOTE 2: place your model specific tokenizers in a prefix named as <model_name>_tokenizer
+  #         so the mistral tokenizer goes in mistral_tokenizer, Llama2 tokenizer goes in  llama2_tokenizer
+  tokenizer_prefix: qwen_tokenizer
+
+  # S3 prefix for prompt templates
+  prompt_template_dir: prompt_template
+
+  # prompt template to use, NOTE: same prompt template gets used for all models being tested through a config file
+  # the FMBench repo already contains a bunch of prompt templates so review those first before creating a new one
+  prompt_template_file: prompt_template_qwen.txt
+
+# steps to run, usually all of these would be
+# set to yes so nothing needs to change here
+# you could, however, bypass some steps for example
+# set the 2_deploy_model.ipynb to no if you are re-running
+# the same config file and the model is already deployed
+run_steps:
+  0_setup.ipynb: yes
+  1_generate_data.ipynb: yes
+  2_deploy_model.ipynb: yes
+  3_run_inference.ipynb: yes
+  4_model_metric_analysis.ipynb: yes
+  5_cleanup.ipynb: no
+
+datasets:
+  # dataset related configuration
+  prompt_template_keys:
+  - input
+  - context
+  
+  # if your dataset has multiple languages and it has a language
+  # field then you could filter it for a language. Similarly,
+  # you can filter your dataset to only keep prompts between
+  # a certain token length limit (the token length is determined
+  # using the tokenizer you provide in the tokenizer_prefix prefix in the
+  # read S3 bucket). Each of the array entries below create a payload file
+  # containing prompts matching the language and token length criteria.
+  filters:
+  - language: en    
+    min_length_in_tokens: 1
+    max_length_in_tokens: 500
+    payload_file: payload_en_1-500.jsonl
+  - language: en
+    min_length_in_tokens: 500
+    max_length_in_tokens: 1000
+    payload_file: payload_en_500-1000.jsonl
+  - language: en
+    min_length_in_tokens: 1000
+    max_length_in_tokens: 2000
+    payload_file: payload_en_1000-2000.jsonl
+  - language: en
+    min_length_in_tokens: 2000
+    max_length_in_tokens: 3000
+    payload_file: payload_en_2000-3000.jsonl
+  - language: en
+    min_length_in_tokens: 3000
+    max_length_in_tokens: 3840
+    payload_file: payload_en_3000-3840.jsonl
+
+# While the tests would run on all the datasets
+# configured in the experiment entries below but 
+# the price:performance analysis is only done for 1
+# dataset which is listed below as the dataset_of_interest
+metrics:
+  dataset_of_interest: en_3000-3840
+  
+# all pricing information is in the pricing.yml file
+# this file is provided in the repo. You can add entries
+# to this file for new instance types and new Bedrock models
+pricing: pricing.yml 
+
+# inference parameters, these are added to the payload
+# for each inference request. The list here is not static
+# any parameter supported by the inference container can be
+# added to the list. Put the sagemaker parameters in the sagemaker
+# section, bedrock parameters in the bedrock section (not shown here).
+# Use the section name (sagemaker in this example) in the inference_spec.parameter_set
+# section under experiments.
+inference_parameters: 
+  ec2_djl:
+    do_sample: yes
+    temperature: 0.1
+    top_p: 0.92
+    top_k: 120  
+    max_new_tokens: 100
+
+
+# Configuration for experiments to be run. The experiments section is an array
+# so more than one experiments can be added, these could belong to the same model
+# but different instance types, or different models, or even different hosting
+# options.
+experiments:
+  - name: {model_id}
+    # AWS region, this parameter is templatized, no need to change
+    region: {region}
+    # model_id is interpreted in conjunction with the deployment_script, so if you
+    # use a JumpStart model id then set the deployment_script to jumpstart.py.
+    # if deploying directly from HuggingFace this would be a HuggingFace model id
+    # see the DJL serving deployment script in the code repo for reference. 
+    #from huggingface to grab
+    model_id: {model_id} # model id, version and image uri not needed for byo endpoint
+    hf_model_id: {model_id}
+    model_version:
+    model_name: {model_id}
+    # this can be changed to the IP address of your specific EC2 instance where the model is hosted
+    ep_name: 'http://127.0.0.1:8080/invocations' 
+    instance_type: {instance_type}
+    image_uri: 763104351884.dkr.ecr.{region}.amazonaws.com/djl-inference:0.29.0-lmi11.0.0-cu124
+    deploy: yes #setting to yes to run deployment script for ec2
+    instance_count: 
+    deployment_script: ec2_deploy.py
+    # FMBench comes packaged with multiple inference scripts, such as scripts for SageMaker
+    # and Bedrock. You can also add your own. This is an example for a rest DJL predictor
+    # for a Qwen deployed on ec2
+    inference_script: ec2_predictor.py
+    # This section defines the settings for Amazon EC2 instances
+    ec2:
+      #This setting specifies the timeout (in seconds) for loading the model. In this case, the timeout is set to 2400 seconds, which is 40 minutes. 
+      # If the model takes longer than 40 minutes to load, the process will time out and fail.
+      model_loading_timeout: 2400
+    inference_spec:
+      # this should match one of the sections in the inference_parameters section above
+      parameter_set: ec2_djl
+      # how many copies of the model, 1, 2,..max
+      # set to 1 in the code if not configured, setting to max means that 
+      # the code will determine how many copies can be loaded based on TP and 
+      # number of GPU/Neuron devices available
+      model_copies: max
+      # if you set the model_copies parameter then it is mandatory to set the 
+      # tp_degree, shm_size, model_loading_timeout parameters
+      tp_degree: {tp_degree}
+      shm_size: 12g
+      model_loading_timeout: 2400
+    # modify the serving properties to match your model and requirements
+    serving.properties: |
+      engine=MPI
+      option.tensor_parallel_degree={tp_degree}
+      option.max_rolling_batch_size={batch_size}
+      option.model_id={model_id}
+      # Setting this to 68832 because the default max model len that djl sets is 131702.
+      # For Qwen, the default max model len that djl sets (131072) cannot be larger than the
+      # maximum number of tokens that can be stored in the KV cache. For Qwen2.5-72b, the 
+      # max tokens that can be stored in the KV cache is 68832
+      option.max_model_len={max_model_len}
+      option.rolling_batch=lmi-dist
+    # runs are done for each combination of payload file and concurrency level
+    payload_files:
+    - payload_en_1-500.jsonl
+    - payload_en_500-1000.jsonl
+    - payload_en_1000-2000.jsonl
+    - payload_en_2000-3000.jsonl
+    - payload_en_3000-3840.jsonl
+    # concurrency level refers to number of requests sent in parallel to an endpoint
+    # the next set of requests is sent once responses for all concurrent requests have
+    # been received.
+    concurrency_levels:
+    - 1
+    - 2
+    - 4
+    - 6
+    - 8
+    
+    # Environment variables to be passed to the container
+    # this is not a fixed list, you can add more parameters as applicable.
+    env:
+
+report:
+  latency_budget: 2
+  cost_per_10k_txn_budget: 100
+  error_rate_budget: 0
+  per_inference_request_file: per_inference_request_results.csv
+  all_metrics_file: all_metrics.csv
+  txn_count_for_showing_cost: 10000
+  v_shift_w_single_instance: 0.025
+  v_shift_w_gt_one_instance: 0.025  

--- a/configs/qwen/qwen.yml
+++ b/configs/qwen/qwen.yml
@@ -13,7 +13,7 @@ defaults: &ec2_settings
   startup_script: startup_scripts/ubuntu_startup.txt
   post_startup_script: post_startup_scripts/fmbench.txt
   # Timeout period in Seconds before a run is stopped
-  fmbench_complete_timeout: 2400
+  fmbench_complete_timeout: 10000
   
 instances:
 - instance_type: g6e.12xlarge
@@ -39,7 +39,7 @@ instances:
   - local: custom_prompt_templates/prompt_template_qwen.txt
     remote: /tmp/fmbench-read/prompt_template/
   post_startup_script_params:
-    additional_args: -A model_id=Qwen/Qwen2.5-72B -A instance_type=g6e.24xlarge -A tp_degree=4 -A batch_size=4 -A results_dir=Qwen2.5-72B-g6e.12xl -A tokenizer_dir=qwen_tokenizer -A prompt_template=prompt_template_qwen.txt -A max_model_len=68823
+    additional_args: -A model_id=Qwen/Qwen2.5-72B -A instance_type=g6e.24xlarge -A tp_degree=4 -A batch_size=4 -A results_dir=Qwen2.5-72B-g6e.24xl -A tokenizer_dir=qwen_tokenizer -A prompt_template=prompt_template_qwen.txt -A max_model_len=68823
 - instance_type: g6e.48xlarge
   deploy: yes
   <<: *ec2_settings
@@ -49,6 +49,6 @@ instances:
   - local: custom_prompt_templates/prompt_template_qwen.txt
     remote: /tmp/fmbench-read/prompt_template/
   post_startup_script_params:
-    additional_args: -A model_id=Qwen/Qwen2.5-72B -A instance_type=g6e.24xlarge -A tp_degree=8 -A batch_size=4 -A results_dir=Qwen2.5-72B-g6e.12xl -A tokenizer_dir=qwen_tokenizer -A prompt_template=prompt_template_qwen.txt -A max_model_len=68823
+    additional_args: -A model_id=Qwen/Qwen2.5-72B -A instance_type=g6e.48xlarge -A tp_degree=8 -A batch_size=4 -A results_dir=Qwen2.5-72B-g6e.48xl -A tokenizer_dir=qwen_tokenizer -A prompt_template=prompt_template_qwen.txt -A max_model_len=68823
 
 

--- a/configs/qwen/qwen.yml
+++ b/configs/qwen/qwen.yml
@@ -1,0 +1,54 @@
+# general configuration applicable to the entire app
+general:
+  name: llama3.1-8b-g5
+
+defaults: &ec2_settings
+  region: {{region}}
+  ami_id: {{gpu}}
+  device_name: /dev/sda1
+  ebs_del_on_termination: True
+  ebs_Iops: 16000
+  ebs_VolumeSize: 250
+  ebs_VolumeType: gp3
+  startup_script: startup_scripts/ubuntu_startup.txt
+  post_startup_script: post_startup_scripts/fmbench.txt
+  # Timeout period in Seconds before a run is stopped
+  fmbench_complete_timeout: 2400
+  
+instances:
+- instance_type: g6e.12xlarge
+  deploy: yes
+  <<: *ec2_settings
+  fmbench_config: 
+  # This is the generic qwen file that can be used for any qwen model on DJL. This includes
+  # NVIDIA GPUs. Users can bring in their own prompt templates, and configure other serving properties
+  # through the additional args parameter. These additional args are then formatted into the generic
+  # config file which is used on that particular instance to benchmark the model of interest.
+  - configs/qwen/fmbench_qwen.yml
+  upload_files:
+  - local: custom_prompt_templates/prompt_template_qwen.txt
+    remote: /tmp/fmbench-read/prompt_template/
+  post_startup_script_params:
+    additional_args: -A model_id=Qwen/Qwen2.5-72B -A instance_type=g6e.12xlarge -A tp_degree=4 -A batch_size=4 -A results_dir=Qwen2.5-72B-g6e.12xl -A tokenizer_dir=qwen_tokenizer -A prompt_template=prompt_template_qwen.txt -A max_model_len=68832
+- instance_type: g6e.24xlarge
+  deploy: yes
+  <<: *ec2_settings
+  fmbench_config: 
+  - configs/qwen/fmbench_qwen.yml
+  upload_files:
+  - local: custom_prompt_templates/prompt_template_qwen.txt
+    remote: /tmp/fmbench-read/prompt_template/
+  post_startup_script_params:
+    additional_args: -A model_id=Qwen/Qwen2.5-72B -A instance_type=g6e.24xlarge -A tp_degree=4 -A batch_size=4 -A results_dir=Qwen2.5-72B-g6e.12xl -A tokenizer_dir=qwen_tokenizer -A prompt_template=prompt_template_qwen.txt -A max_model_len=68823
+- instance_type: g6e.48xlarge
+  deploy: yes
+  <<: *ec2_settings
+  fmbench_config: 
+  - configs/qwen/fmbench_qwen.yml
+  upload_files:
+  - local: custom_prompt_templates/prompt_template_qwen.txt
+    remote: /tmp/fmbench-read/prompt_template/
+  post_startup_script_params:
+    additional_args: -A model_id=Qwen/Qwen2.5-72B -A instance_type=g6e.24xlarge -A tp_degree=8 -A batch_size=4 -A results_dir=Qwen2.5-72B-g6e.12xl -A tokenizer_dir=qwen_tokenizer -A prompt_template=prompt_template_qwen.txt -A max_model_len=68823
+
+

--- a/configs/qwen/qwen.yml
+++ b/configs/qwen/qwen.yml
@@ -29,6 +29,8 @@ instances:
   - local: custom_prompt_templates/prompt_template_qwen.txt
     remote: /tmp/fmbench-read/prompt_template/
   post_startup_script_params:
+    # Add your additional parameters here based on the model id, the instance type and other parameters that you want to test. All these parameters
+    # will be replaced in the generic config file that is used across different instances (g6e12xlarge, g6e.24xlarge, etc.)
     additional_args: -A model_id=Qwen/Qwen2.5-72B -A instance_type=g6e.12xlarge -A tp_degree=4 -A batch_size=4 -A results_dir=Qwen2.5-72B-g6e.12xl -A tokenizer_dir=qwen_tokenizer -A prompt_template=prompt_template_qwen.txt -A max_model_len=68832
 - instance_type: g6e.24xlarge
   deploy: yes

--- a/custom_prompt_templates/prompt_template_qwen.txt
+++ b/custom_prompt_templates/prompt_template_qwen.txt
@@ -1,0 +1,10 @@
+You are an assistant for question-answering tasks. Use the following pieces of retrieved context in the section demarcated by # to answer the question. If you don't know the answer just say that you don't know. Use three sentences maximum and keep the answer concise.
+
+Context:
+{context}
+
+Question: {input}
+
+Analyze the question carefully, and answer the question accurately with only the required information from the context. There can be multiple question answer pairs in the context. Answer the final question in the question section above after the context.
+
+Answer:

--- a/main.py
+++ b/main.py
@@ -75,6 +75,10 @@ async def execute_fmbench(instance, post_install_script, remote_script_path):
             instance_name = instance["instance_name"]
             local_mode_param = POST_STARTUP_LOCAL_MODE_VAR
             write_bucket_param = POST_STARTUP_WRITE_BUCKET_VAR
+            # If a user has provided the additional generatic command line arguments, those will
+            # be used in the fmbench --config-file command. Such as the model id, the instance type, 
+            # the serving properties, etc.
+            additional_args = ''
 
             logger.info(
                 f"going to run config {cfg_idx} of {num_configs} for instance {instance_name}"
@@ -86,9 +90,12 @@ async def execute_fmbench(instance, post_install_script, remote_script_path):
 
             # override defaults for post install script params if specified
             pssp = instance.get("post_startup_script_params")
+            logger.info(f"User provided post start up script parameters: {pssp}")
             if pssp is not None:
                 local_mode_param = pssp.get("local_mode", local_mode_param)
                 write_bucket_param = pssp.get("write_bucket", write_bucket_param)
+                additional_args = pssp.get("additional_args", additional_args)
+            logger.info(f"Going to use the additional arguments in the command line: {additional_args}")
 
             # Convert `local_mode_param` to "yes" or "no" if it is a boolean
             if isinstance(local_mode_param, bool):
@@ -101,8 +108,10 @@ async def execute_fmbench(instance, post_install_script, remote_script_path):
                     config_file=remote_config_path,
                     local_mode=local_mode_param,
                     write_bucket=write_bucket_param,
+                    additional_args=additional_args,
                 )
             )
+            logger.info(f"Formatted post startup script: {formatted_script}")
 
             
 

--- a/post_startup_scripts/fmbench.txt
+++ b/post_startup_scripts/fmbench.txt
@@ -6,7 +6,7 @@ if [[ "$CONDA_DEFAULT_ENV" == "fmbench_python311" ]]; then
     echo "The current environment is fmbench_python311. Running FMBench..."
     
     # Run fmbench and redirect output to a log file
-    nohup fmbench --config-file {config_file} --local-mode {local_mode} --write-bucket {write_bucket} --tmp-dir /tmp > fmbench.log 2>&1 &
+    nohup fmbench --config-file {config_file} --local-mode {local_mode} --write-bucket {write_bucket} --tmp-dir /tmp {additional_args} > fmbench.log 2>&1 &
     FM_BENCH_PID=$!
     echo "FMBench is running with PID $FM_BENCH_PID. Logs are being written to fmbench.log."
     


### PR DESCRIPTION
This PR contains the following additions:

1. Support for additional parameters to be added to the FMBench config file command line through the orchestrator config file.
2. A generic qwen.yml file is used across all the instances with the only difference in the "additional" parameters that gets added to the FMBench command line run.
3. This is tested with and without additional parameters.