### PR TITLE
modified Dockerfile.cpu path from root directory to docker/

### DIFF
--- a/startup_scripts/cpu_al2023_startup.txt
+++ b/startup_scripts/cpu_al2023_startup.txt
@@ -64,7 +64,7 @@ git clone https://github.com/vllm-project/vllm.git
 cd vllm
 
 # Build a Docker image using the provided Dockerfile for CPU, with a shared memory size of 4GB
-sudo docker build -f Dockerfile.cpu -t vllm-cpu-env --shm-size=4g .
+sudo docker build -f ./docker/Dockerfile.cpu -t vllm-cpu-env --shm-size=4g .
 
 DOCKER_CONFIG=${DOCKER_CONFIG:-$HOME/.docker}
 mkdir -p $DOCKER_CONFIG/cli-plugins


### PR DESCRIPTION

*Issue #, if available:*

file : cpu_al2023_startup.txt
```
# Clone the vLLM project repository from GitHub
git clone https://github.com/vllm-project/vllm.git

# Change the directory to the cloned vLLM project
cd vllm

# Build a Docker image using the provided Dockerfile for CPU, with a shared memory size of 4GB
sudo docker build -f Dockerfile.cpu -t vllm-cpu-env --shm-size=4g .
```
docker build fail.

The Dockerfile.cpu was previously located in the vllm root directory, but has been moved to the docker/
vllm:https://github.com/vllm-project/vllm/blob/main/docker/Dockerfile.cpu

*Description of changes:*

Update Dockerfile.cpu path from ./  to  docker/ 

``` bash
sudo docker build -f ./docker/Dockerfile.cpu -t vllm-cpu-env --shm-size=4g .
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
